### PR TITLE
Add GetAllChangelists, GetChangelistsDelta actions

### DIFF
--- a/action.go
+++ b/action.go
@@ -192,7 +192,7 @@ func (c *Connection) Print(path string, clNumber int) ([]byte, error) {
 	}
 }
 
-// Get changelists starting from n-th changelist and return a ChangeList slice.
+// GetAllChangelists gets changelists starting from n-th changelist and return a ChangeList slice.
 func (c *Connection) GetAllChangelists(depot string, changeFrom int) ([]ChangeList, error) {
 	changelists := []ChangeList{}
 	if data, err := c.execP4("changes", "-e", strconv.Itoa(changeFrom), depot); err == nil {
@@ -221,7 +221,7 @@ func (c *Connection) GetAllChangelists(depot string, changeFrom int) ([]ChangeLi
 	}
 }
 
-// Return all CL's between two CL's from a slice of CL's.
+// GetChangelistsDelta Returns all CL's between two CL's from a slice of CL's.
 func (c *Connection) GetChangelistsDelta(clFrom int, clTo int, changelist []ChangeList) ([]ChangeList, error) {
 	delta := []ChangeList{}
 	for _, change := range changelist {

--- a/action.go
+++ b/action.go
@@ -201,10 +201,12 @@ func (c *Connection) GetAllChangelists(depot string, changeFrom int) ([]ChangeLi
 		for _, changelist := range submatch {
 			intChange, err := strconv.Atoi(string(changelist[1]))
 			if err != nil {
+				fmt.Printf("Failed to parse int from string:'%s'", string(changelist[1]))
 				return nil, err
 			}
 			dateChange, err := time.Parse("2006/01/02", string(changelist[2]))
 			if err != nil {
+				fmt.Printf("Failed to parse date from string:'%s'", string(changelist[2]))
 				return nil, err
 			}
 			changelists = append(changelists, ChangeList{

--- a/connection.go
+++ b/connection.go
@@ -29,8 +29,8 @@ func Connect(port string, username string, password string, client string) *Conn
 func (c *Connection) execP4(args ...string) ([]byte, error) {
 	env := []string{
 		"HOME=" + os.Getenv("HOME"),
-		"P4PORT=" + c.port,
 		"P4CLIENT=" + c.client,
+		"P4PORT=" + c.port,
 		"P4USER=" + c.username,
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -10,15 +10,15 @@ import (
 var tokenRegexp = regexp.MustCompile("([0-9A-Z]{32})")
 
 type Connection struct {
-	host     string
+	port     string
 	username string
 	password string
 	client   string
 }
 
-func Connect(host string, username string, password string, client string) *Connection {
+func Connect(port string, username string, password string, client string) *Connection {
 	c := new(Connection)
-	c.host = host
+	c.port = port
 	c.username = username
 	c.password = password
 	c.client = client
@@ -29,7 +29,7 @@ func Connect(host string, username string, password string, client string) *Conn
 func (c *Connection) execP4(args ...string) ([]byte, error) {
 	env := []string{
 		"HOME=" + os.Getenv("HOME"),
-		"P4HOST=" + c.host,
+		"P4PORT=" + c.port,
 		"P4CLIENT=" + c.client,
 		"P4USER=" + c.username,
 	}
@@ -40,7 +40,7 @@ func (c *Connection) execP4(args ...string) ([]byte, error) {
 
 	password.Write([]byte(c.password))
 
-	cmd := exec.Command("p4", "login")
+	cmd := exec.Command("p4", "login", "-p")
 	cmd.Env = env
 	cmd.Stdin = &password
 	cmd.Stdout = &token

--- a/connection.go
+++ b/connection.go
@@ -10,15 +10,15 @@ import (
 var tokenRegexp = regexp.MustCompile("([0-9A-Z]{32})")
 
 type Connection struct {
-	port     string
+	host     string
 	username string
 	password string
 	client   string
 }
 
-func Connect(port string, username string, password string, client string) *Connection {
+func Connect(host string, username string, password string, client string) *Connection {
 	c := new(Connection)
-	c.port = port
+	c.host = host
 	c.username = username
 	c.password = password
 	c.client = client
@@ -29,8 +29,8 @@ func Connect(port string, username string, password string, client string) *Conn
 func (c *Connection) execP4(args ...string) ([]byte, error) {
 	env := []string{
 		"HOME=" + os.Getenv("HOME"),
+		"P4HOST=" + c.host,
 		"P4CLIENT=" + c.client,
-		"P4PORT=" + c.port,
 		"P4USER=" + c.username,
 	}
 
@@ -40,7 +40,7 @@ func (c *Connection) execP4(args ...string) ([]byte, error) {
 
 	password.Write([]byte(c.password))
 
-	cmd := exec.Command("p4", "login", "-p")
+	cmd := exec.Command("p4", "login")
 	cmd.Env = env
 	cmd.Stdin = &password
 	cmd.Stdout = &token


### PR DESCRIPTION
This work started due to us wanting to be able to use suspect commits in Sentry with Releases correctly.